### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/Foo.pm
+++ b/lib/Foo.pm
@@ -1,3 +1,3 @@
-class Foo;
+unit class Foo;
 
 method ver { v1.0 }


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class`, `role` or `grammar` declarations (unless it uses a
block).  Code still using the old blockless semicolon form will throw a
warning. This commit stops the warning from appearing in the new Rakudo.
